### PR TITLE
Bump Sober to 2025-04-09_30ecd1e

### DIFF
--- a/org.vinegarhq.Sober.yml
+++ b/org.vinegarhq.Sober.yml
@@ -49,8 +49,8 @@ modules:
     sources:
       - type: archive
         # *** The notice applies to the binaries we distribute. See: https://sober.vinegarhq.org/notice.txt
-        url: https://sober.vinegarhq.org/artifacts/2025-04-08_d9d4da3/sober-binaries-unified.tar.zst
+        url: https://sober.vinegarhq.org/artifacts/2025-04-09_30ecd1e/sober-binaries-unified.tar.zst
         strip-components: 1
-        sha256: 2afc9060ace159e19fd34a8ed508c5ef87d5ecec62cd8c2f4733dc632f2aaf8b
+        sha256: 1aa16fb13945b149b6e200556383b45a0443d1e94d0f64843db97390dd949520
         only-arches:
           - x86_64


### PR DESCRIPTION
fixes some startup crashes, caches assets for smoother gameplay.