### PR TITLE
Bump Sober to 2025-05-20_906ada0

### DIFF
--- a/org.vinegarhq.Sober.yml
+++ b/org.vinegarhq.Sober.yml
@@ -49,8 +49,8 @@ modules:
     sources:
       - type: archive
         # *** The notice applies to the binaries we distribute. See: https://sober.vinegarhq.org/notice.txt
-        url: https://sober.vinegarhq.org/artifacts/2025-04-25_a36e5f1/sober-binaries-unified.tar.zst
+        url: https://sober.vinegarhq.org/artifacts/2025-05-20_906ada0/sober-binaries-unified.tar.zst
         strip-components: 1
-        sha256: 6224c578021ee9100513df88e19476bbe4ee657beb23bbb0a29627859b6e7b01
+        sha256: 06305d644fabfc60b61a9a823fc7bea41d36c18de25435d51eba9b322c3b3cc5
         only-arches:
           - x86_64


### PR DESCRIPTION
Updates the Roblox version to 2.673.1715, fixes bugs especially related to touchscreen, adds GameMode support. More info in the metainfo as per usual.